### PR TITLE
Removing mention of Gemfile from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,6 @@ A command-line tool that automagically reorganizes your Xcode project folder.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
-    gem 'synx'
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
     $ gem install synx
 
 ## Usage


### PR DESCRIPTION
Realistically, most people installing this tool will not be invoking it within the context of a Ruby application. I found these details confusing—or at the very least, unexpected—on my first read-through.
