### PR TITLE
Fix regex escaping causing sync issues on paths with special characters

### DIFF
--- a/lib/synx/project.rb
+++ b/lib/synx/project.rb
@@ -87,7 +87,7 @@ module Synx
     end
 
     def pathname_is_inside_root_pathname?(grandchild_pathname)
-      grandchild_pathname.realpath.to_s =~ /^#{root_pathname.realpath.to_s}/
+      grandchild_pathname.realpath.to_s.start_with?(root_pathname.realpath.to_s)
     end
 
     def group_exclusions=(new_exclusions)


### PR DESCRIPTION
Previously, with paths containing parens `(` `)`, Synx fails to sync groups as it does not believe files are within the root pathname for their project.

This fix replaces the regex with a `start_with?` check, fixing the regex issue.

Thanks to @marklarr for lots of things. :punch: 
