### PR TITLE
Remove class variables from Tabber

### DIFF
--- a/lib/synx/tabber.rb
+++ b/lib/synx/tabber.rb
@@ -1,39 +1,39 @@
 module Synx
   class Tabber
 
-    @@options = {}
-    @@tabbing = 0
+    @options = {}
+    @tabbing = 0
 
     class << self
       def increase(n=1)
-        @@tabbing += n
+        @tabbing += n
       end
 
       def decrease(n=1)
-       @@tabbing -= n
-       @@tabbing = 0 if @@tabbing < 0
+       @tabbing -= n
+       @tabbing = 0 if @tabbing < 0
       end
 
       def current
-        @@tabbing
+        @tabbing
       end
 
       def reset
-        @@tabbing = 0
+        @tabbing = 0
         self.options = {}
       end
 
       def options=(options = {})
-        @@options = options
+        @options = options
       end
 
       def options
-        @@options
+        @options
       end
 
       def puts(str="")
         str = str.uncolorize if options[:no_color]
-        Kernel.puts (a_single_tab * @@tabbing) + str.to_s unless options[:quiet]
+        Kernel.puts (a_single_tab * @tabbing) + str.to_s unless options[:quiet]
       end
 
       def a_single_tab


### PR DESCRIPTION
@@vars are generally considered a Bad Thing in Ruby.
See http://bit.ly/1kcit9V for a quick rationale.
