### PR TITLE
Remove output from tests

### DIFF
--- a/lib/synx/project.rb
+++ b/lib/synx/project.rb
@@ -18,7 +18,7 @@ module Synx
       Synx::Tabber.increase
       Synx::Tabber.puts "Syncing files that are included in Xcode project...".bold.white
       main_group.all_groups.each { |gr| gr.sync(main_group) }
-      puts "\n\n" unless options[:quiet]
+      Synx::Tabber.puts "\n\n"
       Synx::Tabber.puts "Syncing files that are not included in Xcode project..".bold.white
       main_group.all_groups.each(&:move_entries_not_in_xcodeproj)
       transplant_work_project

--- a/lib/synx/tabber.rb
+++ b/lib/synx/tabber.rb
@@ -33,13 +33,18 @@ module Synx
 
       def puts(str="")
         str = str.uncolorize if options[:no_color]
-        Kernel.puts (a_single_tab * @tabbing) + str.to_s unless options[:quiet]
+        output.puts (a_single_tab * @tabbing) + str.to_s unless options[:quiet]
       end
 
       def a_single_tab
         return "  "
       end
       private :a_single_tab
+
+      def output
+        options.fetch(:output, $stdout)
+      end
+      private :output
 
     end
   end

--- a/spec/synx/project_spec.rb
+++ b/spec/synx/project_spec.rb
@@ -95,7 +95,7 @@ describe Synx::Project do
     describe "with no additional options" do
 
       before(:all) do
-        DUMMY_SYNX_TEST_PROJECT.sync
+        DUMMY_SYNX_TEST_PROJECT.sync(:output => StringIO.new)
       end
 
       it "should have the correct physical file structure" do
@@ -124,7 +124,7 @@ describe Synx::Project do
     describe "with the prune option toggled" do
 
       before(:all) do
-        DUMMY_SYNX_TEST_PROJECT.sync(:prune => true)
+        DUMMY_SYNX_TEST_PROJECT.sync(:prune => true, :output => StringIO.new)
       end
 
       it "should remove unreferenced images and source files if the prune option is toggled" do
@@ -143,7 +143,7 @@ describe Synx::Project do
     describe "with the no_default_exclusions option toggled" do
 
       before(:all) do
-        DUMMY_SYNX_TEST_PROJECT.sync(:no_default_exclusions => true)
+        DUMMY_SYNX_TEST_PROJECT.sync(:no_default_exclusions => true, :output => StringIO.new)
       end
 
       it "should have an empty array for default exclusions" do
@@ -154,7 +154,7 @@ describe Synx::Project do
     describe "with group_exclusions provided as options" do
 
       before(:all) do
-        DUMMY_SYNX_TEST_PROJECT.sync(:group_exclusions => %W(/dummy /dummy/SuchGroup/VeryChildGroup))
+        DUMMY_SYNX_TEST_PROJECT.sync(:group_exclusions => %W(/dummy /dummy/SuchGroup/VeryChildGroup), :output => StringIO.new)
       end
 
       it "should add the group exclusions to the array" do

--- a/spec/synx/tabber_spec.rb
+++ b/spec/synx/tabber_spec.rb
@@ -4,7 +4,10 @@ describe Synx::Tabber do
 
   before(:each) do
     Synx::Tabber.reset
+    Synx::Tabber.options[:output] = output
   end
+
+  let(:output) { StringIO.new }
 
   describe "::increase" do
     it "should default to increasing tabbing by 1" do
@@ -48,27 +51,34 @@ describe Synx::Tabber do
   end
 
   describe "::puts" do
-    it "should call system's puts on the string, appending the appropraite indentation" do
+    it "should print to the output io with the appropriate indentation" do
       Synx::Tabber.increase(3)
-      expect(Kernel).to receive(:puts).with("      Hello, world.")
       Synx::Tabber.puts("Hello, world.")
+      expect(output.string).to eq("      Hello, world.\n")
     end
 
     it "should not print anything if quiet is true" do
-      Synx::Tabber.options = { quiet: true }
-      expect(Kernel).to_not receive(:puts)
+      Synx::Tabber.options[:quiet] = true
       Synx::Tabber.puts("Hello, world.")
+      expect(output.string).to eq("")
     end
 
     it "should print colors if no_color is false or not present" do
-      expect(Kernel).to receive(:puts).with("\e[0;31;49mHello, world.\e[0m")
       Synx::Tabber.puts("Hello, world.".red)
+      expect(output.string).to eq("\e[0;31;49mHello, world.\e[0m\n")
     end
 
     it "should not print colors if no_color is true" do
-      Synx::Tabber.options = { no_color: true }
-      expect(Kernel).to receive(:puts).with("Hello, world.")
+      Synx::Tabber.options[:no_color] = true
       Synx::Tabber.puts("Hello, world.".red)
+      expect(output.string).to eq("Hello, world.\n")
+    end
+
+    it "prints to stdout if no output is specified" do
+      expect($stdout).to receive(:puts).with("  Hello, world.")
+      Synx::Tabber.reset
+      Synx::Tabber.increase
+      Synx::Tabber.puts("Hello, world.")
     end
   end
 


### PR DESCRIPTION
`Tabber` accepts an `:output` option, which points to `$stdout` by default.
Tests set this option to a `StringIO` object instead.

If you like the output for acceptance testing, feel free to close this. But a high-level test that makes explicit assertions about the format of the output would be better imo. In fact, I might just write that test :)

I'll rebase if https://github.com/venmo/synx/pull/36 gets merged first and you like this change.
