### PR TITLE
Fix various `require` and `File.join` calls.

### DIFF
--- a/bin/synx
+++ b/bin/synx
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'clamp'
-require File.join(File.dirname(__FILE__), '..', 'lib', 'synx')
+require 'synx'
 
 Clamp do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,9 @@
 require 'bundler/setup'
-Bundler.setup
-
 require 'synx'
 require 'pry'
 
-DUMMY_SYNX_PATH = File.join(File.dirname(__FILE__), 'dummy')
-DUMMY_SYNX_TEST_PATH = File.join(File.dirname(__FILE__), 'test_dummy')
+DUMMY_SYNX_PATH = File.expand_path('../dummy', __FILE__)
+DUMMY_SYNX_TEST_PATH = File.expand_path('../test_dummy', __FILE__)
 DUMMY_SYNX_TEST_PROJECT_PATH = File.join(DUMMY_SYNX_TEST_PATH, 'dummy.xcodeproj')
 FileUtils.rm_rf(DUMMY_SYNX_TEST_PATH)
 FileUtils.cp_r(DUMMY_SYNX_PATH, DUMMY_SYNX_TEST_PATH)

--- a/spec/synx/pbx_group_spec.rb
+++ b/spec/synx/pbx_group_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+require 'spec_helper'
 
 describe Xcodeproj::Project::Object::PBXGroup do
 

--- a/spec/synx/project_spec.rb
+++ b/spec/synx/project_spec.rb
@@ -1,5 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
-
+require 'spec_helper'
 require 'fileutils'
 require 'pathname'
 require 'yaml'
@@ -86,11 +85,11 @@ describe Synx::Project do
     end
 
     def expected_file_structure
-      YAML::load_file(File.join(File.dirname(__FILE__), "expected_file_structure.yml"))
+      YAML::load_file(File.expand_path("../expected_file_structure.yml", __FILE__))
     end
 
     def expected_group_structure
-      YAML::load_file(File.join(File.dirname(__FILE__), "expected_group_structure.yml"))
+      YAML::load_file(File.expand_path("../expected_group_structure.yml", __FILE__))
     end
 
     describe "with no additional options" do

--- a/spec/synx/tabber_spec.rb
+++ b/spec/synx/tabber_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+require 'spec_helper'
 
 describe Synx::Tabber do
 


### PR DESCRIPTION
In many cases it's safe to assume the load path will be setup correctly
at runtime, eliminating the need for absolute paths. For instance, in
your bin/synx executable, RubyGems sets the load path such that you can
just `require "synx"`. When you use RSpec, it also sets the load path to
allow you to use `require "spec_helper"`.

I also cleaned up the `File.join(File.dirname(__FILE__)...` stuff to use
the more idiomatic `File.expand_path`.

Hope you don't mind all the PRs. There are more coming too. You can thank
@ayanonagon for her inspiring talk on OSS ;)
