### PR TITLE
added “warn only” option

### DIFF
--- a/bin/synx
+++ b/bin/synx
@@ -6,6 +6,7 @@ require 'synx'
 Clamp do
 
   parameter "xcodeproj", "Path to the xcodeproj", :attribute_name => :xcodeproj_path
+  option ["--warn-only", "-w"], :flag, "show warnings for files whose paths do not match the project structure, but do not make any changes"
   option ["--prune", "-p"], :flag, "remove source files and image resources that are not referenced by the the xcode project"
   option "--no-color", :flag, "removes all color from the output"
   option "--no-default-exclusions", :flag, "doesn't use the default exclusions of /Libraries, /Frameworks, and /Products"
@@ -21,7 +22,7 @@ Clamp do
       puts "You cannot run Synx as root.".red
     else
       project = Synx::Project.open(xcodeproj_path)
-      project.sync(:prune => prune?, :quiet => quiet?, :no_color => no_color?, :no_default_exclusions => no_default_exclusions?, :group_exclusions => exclusion_list)
+      project.sync(:warn_only_non_destructive => warn_only?, :prune => prune?, :quiet => quiet?, :no_color => no_color?, :no_default_exclusions => no_default_exclusions?, :group_exclusions => exclusion_list)
     end
   end
 

--- a/lib/synx/project.rb
+++ b/lib/synx/project.rb
@@ -17,7 +17,9 @@ module Synx
       presync_check
       Synx::Tabber.increase
       Synx::Tabber.puts "Syncing files that are included in Xcode project...".bold.white
-      main_group.all_groups.each { |gr| gr.sync(main_group) }
+      warn_only = options[:warn_only_non_destructive]
+      main_group.all_groups.each { |gr| gr.sync(main_group, warn_only) }
+      return if warn_only==true
       Synx::Tabber.puts "\n\n"
       Synx::Tabber.puts "Syncing files that are not included in Xcode project..".bold.white
       main_group.all_groups.each(&:move_entries_not_in_xcodeproj)

--- a/lib/synx/xcodeproj_ext/project/object/pbx_group.rb
+++ b/lib/synx/xcodeproj_ext/project/object/pbx_group.rb
@@ -3,7 +3,7 @@ module Xcodeproj
     module Object
       class PBXGroup
 
-        def sync(group)
+        def sync(group, warn_only)
           ensure_internal_consistency(group) # Make sure we don't belong to any other groups
           if excluded_from_sync?
             Synx::Tabber.puts "#{basename}/ (excluded)".yellow
@@ -17,11 +17,11 @@ module Xcodeproj
             # inside the loops.
             files.each do |pbx_file|
               pbx_file.work_pathname.dirname.mkpath
-              pbx_file.sync(self)
+              pbx_file.sync(self, warn_only)
             end
             all_groups.each do |group|
               group.work_pathname.dirname.mkpath
-              group.sync(self)
+              group.sync(self, warn_only)
             end
             sync_path
 


### PR DESCRIPTION
...form the developer before every build.

you can convert these warnings to errors by substituting “warning” for “error” in the output using `sed` as follows:

```
sync -w Example.xcodeproj | perl -p -e “s/warning: /error: /“
```