### PR TITLE
Fix #68

### DIFF
--- a/lib/synx/xcodeproj_ext/project/object/abstract_object.rb
+++ b/lib/synx/xcodeproj_ext/project/object/abstract_object.rb
@@ -20,7 +20,7 @@ module Xcodeproj
             @work_pathname ||= project.work_root_pathname
           elsif parent.is_a?(Xcodeproj::Project::Object::PBXVariantGroup)
             # Localized object, naming is handled differently.
-            @work_pathname ||= parent.work_pathname + "#{display_name}.lproj" + parent.display_name
+            @work_pathname ||= parent.work_pathname + path
           elsif is_a?(Xcodeproj::Project::Object::PBXVariantGroup)
             # Localized container, has no path of its own.
             @work_pathname ||= parent.work_pathname


### PR DESCRIPTION
I've found where is the problem. It's wrong to use parent.display_name to build child name, because in case of localised .xib or .storyboard files localised version could be an .strings file as described in issue.

I'm not a Ruby developer. I didn't understand the full meaning of 'parent' and 'child' (self) here and meaning of their properties. I've found the roots of the problem here with debugger and this commit fixed it. My tests didn't reveal any new problems.

Maybe there is more suitable way to build correct path here. Please, consider it before accepting this pull request :)