### PR TITLE
Update "xcodeproj" dependency version to be more promiscuous

### DIFF
--- a/synx.gemspec
+++ b/synx.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "clamp", "~> 0.6"
   spec.add_dependency "colorize", "~> 0.7"
-  spec.add_dependency "xcodeproj", "~> 0.24.1"
+  spec.add_dependency "xcodeproj", "~> 0.24"
 end


### PR DESCRIPTION
Requiring `0.24.1` makes this gem incompatible with CocoaPods:

```
Bundler could not find compatible versions for gem "xcodeproj":
  In Gemfile:
    cocoapods (~> 0.38) ruby depends on
      xcodeproj (~> 0.26.2) ruby

    synx (~> 0.1) ruby depends on
      xcodeproj (0.24.1)
```

`0.24` should be sufficient.