### PR TITLE
Pin Xcodeproj to ~> 0.28.2

### DIFF
--- a/synx.gemspec
+++ b/synx.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "clamp", "~> 0.6"
   spec.add_dependency "colorize", "~> 0.7"
-  spec.add_dependency "xcodeproj", "~> 0.24.1"
+  spec.add_dependency "xcodeproj", "~> 0.28.2"
 end


### PR DESCRIPTION
Xcodeproj 0.28.2 has a few fixes for El Capitan and Xcode 7 and would close #85.