### PR TITLE
Relax the gem requirement

### DIFF
--- a/synx.gemspec
+++ b/synx.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 2.14"
   spec.add_development_dependency "pry", "~> 0.9"
 
-  spec.add_dependency "clamp", ">= 0.6"
-  spec.add_dependency "colorize", ">= 0.7"
-  spec.add_dependency "xcodeproj", ">= 0.28.2"
+  spec.add_dependency "clamp", "~> 1.0"
+  spec.add_dependency "colorize", "~> 0.7"
+  spec.add_dependency "xcodeproj", "~> 1.0"
 end

--- a/synx.gemspec
+++ b/synx.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 2.14"
   spec.add_development_dependency "pry", "~> 0.9"
 
-  spec.add_dependency "clamp", "~> 0.6"
-  spec.add_dependency "colorize", "~> 0.7"
-  spec.add_dependency "xcodeproj", "~> 0.28.2"
+  spec.add_dependency "clamp", ">= 0.6"
+  spec.add_dependency "colorize", ">= 0.7"
+  spec.add_dependency "xcodeproj", ">= 0.28.2"
 end


### PR DESCRIPTION
This gem don't really need exactly those versions of dependencies. Relax the requirement will allow us use it when some other gems depended on a higher version.