### PR TITLE
Using xcodeproj 1.0.0

### DIFF
--- a/synx.gemspec
+++ b/synx.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "clamp", "~> 0.6"
   spec.add_dependency "colorize", "~> 0.7"
-  spec.add_dependency "xcodeproj", "~> 0.28.2"
+  spec.add_dependency "xcodeproj", "~> 1.0"
 end


### PR DESCRIPTION
`xcodeproj` finally reached [release 1.0.0](https://github.com/CocoaPods/Xcodeproj/releases/tag/1.0.0). I think it's time to make the change 😋 