### PR TITLE
[Gemspec] Bump xcodeproj to `~> 1.5.7`

### DIFF
--- a/synx.gemspec
+++ b/synx.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "clamp", "~> 0.6"
   spec.add_dependency "colorize", "~> 0.7"
-  spec.add_dependency "xcodeproj", "~> 1.0"
+  spec.add_dependency "xcodeproj", "~> 1.5.7"
 end


### PR DESCRIPTION
This PR is to solve a problem with following stacktrace.
```
/Library/Ruby/Gems/2.3.0/gems/atomos-0.1.1/lib/atomos.rb:8:in `atomic_write': undefined method `tmpdir' for Dir:Class (NoMethodError)
	from /Library/Ruby/Gems/2.3.0/gems/xcodeproj-1.5.5/lib/xcodeproj/project.rb:354:in `save'
	from /Library/Ruby/Gems/2.3.0/gems/synx-0.2.1/lib/synx/project.rb:27:in `sync'
	from /Library/Ruby/Gems/2.3.0/gems/synx-0.2.1/bin/synx:25:in `execute'
	from /Library/Ruby/Gems/2.3.0/gems/clamp-0.6.5/lib/clamp/command.rb:67:in `run'
	from /Library/Ruby/Gems/2.3.0/gems/clamp-0.6.5/lib/clamp/command.rb:132:in `run'
	from /Library/Ruby/Gems/2.3.0/gems/clamp-0.6.5/lib/clamp.rb:6:in `Clamp'
	from /Library/Ruby/Gems/2.3.0/gems/synx-0.2.1/bin/synx:6:in `<top (required)>'
	from /usr/local/bin/synx:22:in `load'
	from /usr/local/bin/synx:22:in `<main>'
```

This is caused by `xcodeproj` on which depends `atomos`.
`xcodeproj` fixed this problem in version 1.5.6, and the newest is 1.5.7.

See [Issue on xcodeproj](https://github.com/CocoaPods/Xcodeproj/issues/545)